### PR TITLE
Php 8+ preg_match(): Passing null ... is deprecated

### DIFF
--- a/ip2location-csv-converter.php
+++ b/ip2location-csv-converter.php
@@ -83,7 +83,7 @@ switch ($conversionMode) {
 		while (!feof($file)) {
 			$data = fgetcsv($file);
 
-			if (!preg_match('/^[0-9]+$/', $data[0]) || !preg_match('/^[0-9]+$/', $data[1])) {
+			if (!preg_match('/^[0-9]+$/', (string)$data[0]) || !preg_match('/^[0-9]+$/', (string)$data[1])) {
 				continue;
 			}
 
@@ -114,7 +114,7 @@ switch ($conversionMode) {
 		while (!feof($file)) {
 			$data = fgetcsv($file);
 
-			if (!preg_match('/^[0-9]+$/', $data[0]) || !preg_match('/^[0-9]+$/', $data[1])) {
+			if (!preg_match('/^[0-9]+$/', (string)$data[0]) || !preg_match('/^[0-9]+$/', (string)$data[1])) {
 				continue;
 			}
 
@@ -136,7 +136,7 @@ switch ($conversionMode) {
 		while (!feof($file)) {
 			$data = fgetcsv($file);
 
-			if (!preg_match('/^[0-9]+$/', $data[0]) || !preg_match('/^[0-9]+$/', $data[1])) {
+			if (!preg_match('/^[0-9]+$/', (string)$data[0]) || !preg_match('/^[0-9]+$/', (string)$data[1])) {
 				continue;
 			}
 


### PR DESCRIPTION
Cast to string to avoid php 8.1
`PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in ./vendor/ip2location/ip2location-csv-converter/ip2location-csv-converter.php on line 139`